### PR TITLE
Spelling mistake of has

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [releases]: https://github.com/tduehr/omniauth-cas3/releases
 
 This is a OmniAuth 1.0 compatible port of the previously available
-[OmniAuth CAS strategy][old_omniauth_cas] that was bundled with OmniAuth 0.3. This strategy haas also been updated for CAS protocol version 3.0 and patched to deal with namespace issues.
+[OmniAuth CAS strategy][old_omniauth_cas] that was bundled with OmniAuth 0.3. This strategy has also been updated for CAS protocol version 3.0 and patched to deal with namespace issues.
 
 * [View the documentation][document_up]
 * [Changelog][releases]


### PR DESCRIPTION
I have changed the spelling mistake of haas to has 

I have found this silly one when I am trying to package this gem for Debian which is a dependency for GitLab and I was looking at the README.md file for larger description
